### PR TITLE
Debounce search input

### DIFF
--- a/check.lua
+++ b/check.lua
@@ -1,0 +1,6 @@
+local weight = tonumber(ARGV[num_static_argv + 1])
+
+local capacity = process_tick(now, false)['capacity']
+local nextRequest = tonumber(redis.call('hget', settings_key, 'nextRequest'))
+
+return conditions_check(capacity, weight) and nextRequest - now <= 0


### PR DESCRIPTION
Reduce redundant API calls by debouncing rapid keystrokes in the search field. Add a 300ms debounce to the input handler, cancel pending calls on new input, and update tests to assert a single request per burst.