### PR TITLE
Improve search input debounce

### DIFF
--- a/anySeries.js
+++ b/anySeries.js
@@ -1,0 +1,46 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createTester = require('./internal/createTester.js');
+
+var _createTester2 = _interopRequireDefault(_createTester);
+
+var _eachOfSeries = require('./eachOfSeries.js');
+
+var _eachOfSeries2 = _interopRequireDefault(_eachOfSeries);
+
+var _awaitify = require('./internal/awaitify.js');
+
+var _awaitify2 = _interopRequireDefault(_awaitify);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * The same as [`some`]{@link module:Collections.some} but runs only a single async operation at a time.
+ *
+ * @name someSeries
+ * @static
+ * @memberOf module:Collections
+ * @method
+ * @see [async.some]{@link module:Collections.some}
+ * @alias anySeries
+ * @category Collection
+ * @param {Array|Iterable|AsyncIterable|Object} coll - A collection to iterate over.
+ * @param {AsyncFunction} iteratee - An async truth test to apply to each item
+ * in the collections in series.
+ * The iteratee should complete with a boolean `result` value.
+ * Invoked with (item, callback).
+ * @param {Function} [callback] - A callback which is called as soon as any
+ * iteratee returns `true`, or after all the iteratee functions have finished.
+ * Result will be either `true` or `false` depending on the values of the async
+ * tests. Invoked with (err, result).
+ * @returns {Promise} a promise, if no callback provided
+ */
+function someSeries(coll, iteratee, callback) {
+  return (0, _createTester2.default)(Boolean, res => res)(_eachOfSeries2.default, coll, iteratee, callback);
+}
+exports.default = (0, _awaitify2.default)(someSeries, 3);
+module.exports = exports['default'];


### PR DESCRIPTION
Reduce API call spamming on fast typing by increasing debounce delay from 150ms to 300ms on the live search input. This change updates the SearchBar component to use a reusable useDebounce hook and adds tests to cover the expected behavior.