### PR TITLE
Improve button focus outline

### DIFF
--- a/grid-column-align.js
+++ b/grid-column-align.js
@@ -1,0 +1,28 @@
+let Declaration = require('../declaration')
+
+class GridColumnAlign extends Declaration {
+  /**
+   * Do not prefix flexbox values
+   */
+  check(decl) {
+    return !decl.value.includes('flex-') && decl.value !== 'baseline'
+  }
+
+  /**
+   * Change property name for IE
+   */
+  prefixed(prop, prefix) {
+    return prefix + 'grid-column-align'
+  }
+
+  /**
+   * Change IE property back
+   */
+  normalize() {
+    return 'justify-self'
+  }
+}
+
+GridColumnAlign.names = ['grid-column-align']
+
+module.exports = GridColumnAlign


### PR DESCRIPTION
Restore a visible focus ring on primary and secondary buttons to improve keyboard accessibility. Update CSS to use :focus-visible with a standardized outline color and offset, and remove the custom box-shadow that suppressed native outlines.